### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,10 @@
 
 This MCP (Model Context Protocol) server provides integration between Fibery and any LLM provider supporting the MCP protocol (e.g., Claude for Desktop), allowing you to interact with your Fibery workspace using natural language.
 
+<a href="https://glama.ai/mcp/servers/@Fibery-inc/fibery-mcp-server">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@Fibery-inc/fibery-mcp-server/badge" alt="Fibery Server MCP server" />
+</a>
+
 ## ✨ Features
 - Query Fibery entities using natural language
 - Get information about your Fibery databases and their fields


### PR DESCRIPTION
This PR adds a badge for the [Fibery MCP Server](https://glama.ai/mcp/servers/@Fibery-inc/fibery-mcp-server) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@Fibery-inc/fibery-mcp-server">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@Fibery-inc/fibery-mcp-server/badge" alt="Fibery Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.