### PR TITLE
Fix MCP compatibility with Codex

### DIFF
--- a/src/fibery_mcp_server/tools/current_date.py
+++ b/src/fibery_mcp_server/tools/current_date.py
@@ -10,7 +10,7 @@ def current_date_tool() -> mcp.types.Tool:
     return mcp.types.Tool(
         name=current_date_tool_name,
         description="Get today's date in ISO 8601 format (YYYY-mm-dd.HH:MM:SS.000Z)",
-        inputSchema={"type": "object"},
+        inputSchema={"type": "object", "properties": {}},
     )
 
 

--- a/src/fibery_mcp_server/tools/query.py
+++ b/src/fibery_mcp_server/tools/query.py
@@ -40,6 +40,7 @@ def query_tool() -> mcp.types.Tool:
                 },
                 "q_where": {
                     "type": "array",
+                    "items": {},
                     "description": "\n".join(
                         [
                             'Filter conditions in format [operator, [field_path], value] or ["q/and"|"q/or", ...conditions]. Common usages:',

--- a/src/fibery_mcp_server/tools/schema.py
+++ b/src/fibery_mcp_server/tools/schema.py
@@ -11,7 +11,7 @@ def schema_tool() -> mcp.types.Tool:
     return mcp.types.Tool(
         name=schema_tool_name,
         description="Get list of all databases (their names) in user's Fibery workspace (schema)",
-        inputSchema={"type": "object"},
+        inputSchema={"type": "object", "properties": {}},
     )
 
 


### PR DESCRIPTION
Fix Fibery MCP compatibility with Codex

The Fibery MCP server was starting correctly, but Codex rejected some tools because their JSON schemas were incomplete.

This fixes:
- `fibery__current_date`: missing `properties` on object schema
- `fibery__list_databases`: missing `properties` on object schema
- `fibery__query_database`: missing `items` on `q_where` array schema

After patching the schemas and restarting, the MCP tools load correctly.